### PR TITLE
Update VectorArray bindings

### DIFF
--- a/.ci/job-template.yml
+++ b/.ci/job-template.yml
@@ -9,8 +9,6 @@ jobs:
 
   strategy:
     matrix:
-      9.3_3.7:
-        containerImage: pymor/dealii_py3.7:47f2bf40dd49a64292e482b59fe6631101fdcc2b
       9.3_3.8:
         containerImage: pymor/dealii_py3.8:47f2bf40dd49a64292e482b59fe6631101fdcc2b
       9.3_3.9:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,9 +14,9 @@ jobs:
   source:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: markdown-link-check
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+      uses: renefritze/github-action-markdown-link-check@master
       with:
         use-verbose-mode: 'yes'
         check-modified-files-only: 'yes'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,23 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements
 -   repo: https://github.com/psf/black
-    rev: 21.11b0
+    rev: 22.6.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
         exclude: "^(versioneer.py|src/pymor_dealii/version.py)"
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v13.0.0'
+    rev: 'v14.0.6'
     hooks:
     -   id: clang-format
         exclude: "^lib/pybind11"

--- a/src/pymor_dealii/pymor/gui.py
+++ b/src/pymor_dealii/pymor/gui.py
@@ -13,7 +13,6 @@ class DealIIVisualizer(ImmutableObject):
     def visualize(
         self,
         U,
-        discretization,
         title=None,
         legend=None,
         separate_colorbars=True,
@@ -36,4 +35,7 @@ class DealIIVisualizer(ImmutableObject):
             filenames = ["_".join((base_name, l)) for l in legend]
 
         for u, n in zip(U, filenames):
-            self.impl.visualize(u._list[0].impl, n + ".vtk")
+            uu = u.vectors[0]
+            if uu.imag_part is not None:
+                self.logger.warning('Imaginary part ignored.')
+            self.impl.visualize(uu.real_part.impl, n + ".vtk")

--- a/src/pymor_dealii/pymor/gui.py
+++ b/src/pymor_dealii/pymor/gui.py
@@ -37,5 +37,5 @@ class DealIIVisualizer(ImmutableObject):
         for u, n in zip(U, filenames):
             uu = u.vectors[0]
             if uu.imag_part is not None:
-                self.logger.warning('Imaginary part ignored.')
+                self.logger.warning("Imaginary part ignored.")
             self.impl.visualize(uu.real_part.impl, n + ".vtk")

--- a/src/pymor_dealii/pymor/operator.py
+++ b/src/pymor_dealii/pymor/operator.py
@@ -21,7 +21,9 @@ class DealIIMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
         self.matrix.vmult(r.impl, u.impl)
         return r
 
-    def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None, least_squares=False, prepare_data=None):
+    def _real_apply_inverse_one_vector(
+        self, v, mu=None, initial_guess=None, least_squares=False, prepare_data=None
+    ):
         if least_squares:
             raise NotImplementedError
         r = self.source.real_zero_vector()

--- a/src/pymor_dealii/pymor/operator.py
+++ b/src/pymor_dealii/pymor/operator.py
@@ -2,44 +2,36 @@
 # Copyright 2013-2018 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.operators.interface import Operator
+from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
 
 from pymor_dealii.pymor.vectorarray import DealIIVectorSpace
 import pymor_dealii_bindings as pd2
 
 
-class DealIIMatrixOperator(Operator):
+class DealIIMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
     """Wraps a dealII matrix as an |Operator|."""
-
-    linear = True
 
     def __init__(self, matrix, name=None):
         self.source = DealIIVectorSpace(matrix.m())
         self.range = DealIIVectorSpace(matrix.n())
         self.__auto_init(locals())
 
-    def apply(self, U, mu=None):
-        assert U in self.source
-        R = self.range.zeros(len(U))
-        for u, r in zip(U._list, R._list):
-            self.matrix.vmult(r.impl, u.impl)
-        return R
+    def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+        r = self.range.real_zero_vector()
+        self.matrix.vmult(r.impl, u.impl)
+        return r
 
-    def apply_transpose(self, V, mu=None):
-        assert V in self.range
-        U = self.source.zeros(len(V))
-        for u, r in zip(V._list, U._list):
-            self.matrix.Tvmult(r.impl, u.impl)
-        return U
-
-    def apply_inverse(self, V, mu=None, initial_guess=None, least_squares=False):
-        assert V in self.range
+    def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None, least_squares=False, prepare_data=None):
         if least_squares:
             raise NotImplementedError
-        R = self.source.zeros(len(V))
-        for r, v in zip(R._list, V._list):
-            self.matrix.cg_solve(r.impl, v.impl)
-        return R
+        r = self.source.real_zero_vector()
+        self.matrix.cg_solve(r.impl, v.impl)
+        return r
+
+    def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        r = self.source.real_zero_vector()
+        self.matrix.Tvmult(r.impl, v.impl)
+        return r
 
     def _assemble_lincomb(
         self,

--- a/src/pymor_dealii/pymor/vectorarray.py
+++ b/src/pymor_dealii/pymor/vectorarray.py
@@ -11,7 +11,7 @@ except ImportError:
 
 import numpy as np
 
-from pymor.vectorarrays.list import ListVectorSpace, CopyOnWriteVector
+from pymor.vectorarrays.list import ComplexifiedListVectorSpace, CopyOnWriteVector
 
 
 class DealIIVector(CopyOnWriteVector):
@@ -104,7 +104,10 @@ class DealIIVector(CopyOnWriteVector):
         return DealIIVector(-self.impl)
 
 
-class DealIIVectorSpace(ListVectorSpace):
+class DealIIVectorSpace(ComplexifiedListVectorSpace):
+
+    real_vector_type = DealIIVector
+
     def __init__(self, dim, id=None):
         self.__auto_init(locals())
 
@@ -123,13 +126,13 @@ class DealIIVectorSpace(ListVectorSpace):
     def space_from_dim(cls, dim, id):
         return cls(dim, id)
 
-    def zero_vector(self):
+    def real_zero_vector(self):
         return DealIIVector(pd2.Vector(self.dim))
 
-    def make_vector(self, obj):
+    def real_make_vector(self, obj):
         return DealIIVector(obj)
 
-    def vector_from_numpy(self, data, ensure_copy=False):
-        v = self.zero_vector()
+    def real_vector_from_numpy(self, data, ensure_copy=False):
+        v = self.real_zero_vector()
         v.to_numpy()[:] = data
         return v

--- a/src/pymor_dealii/pymor/vectorarray.py
+++ b/src/pymor_dealii/pymor/vectorarray.py
@@ -48,6 +48,10 @@ class DealIIVector(CopyOnWriteVector):
             return
         if x is self:
             self.impl *= 1.0 + alpha
+        elif x == 1:
+            self.impl += x.impl
+        elif x == -1:
+            self.impl -= x.impl
         else:
             self.impl.axpy(alpha, x.impl)
 
@@ -78,16 +82,6 @@ class DealIIVector(CopyOnWriteVector):
         A = np.abs(self.to_numpy())
         max_ind = np.argmax(A)
         return max_ind, A[max_ind]
-
-    def __iadd__(self, other):
-        self._copy_data_if_needed()
-        self.impl += other.impl
-        return self
-
-    def __isub__(self, other):
-        self._copy_data_if_needed()
-        self.impl -= other.impl
-        return self
 
 
 class DealIIVectorSpace(ComplexifiedListVectorSpace):

--- a/src/pymor_dealii/pymor/vectorarray.py
+++ b/src/pymor_dealii/pymor/vectorarray.py
@@ -79,29 +79,15 @@ class DealIIVector(CopyOnWriteVector):
         max_ind = np.argmax(A)
         return max_ind, A[max_ind]
 
-    def __add__(self, other):
-        return DealIIVector(self.impl + other.impl)
-
     def __iadd__(self, other):
         self._copy_data_if_needed()
         self.impl += other.impl
         return self
 
-    __radd__ = __add__
-
-    def __sub__(self, other):
-        return DealIIVector(self.impl - other.impl)
-
     def __isub__(self, other):
         self._copy_data_if_needed()
         self.impl -= other.impl
         return self
-
-    def __mul__(self, other):
-        return DealIIVector(self.impl * other)
-
-    def __neg__(self):
-        return DealIIVector(-self.impl)
 
 
 class DealIIVectorSpace(ComplexifiedListVectorSpace):


### PR DESCRIPTION
- adds complex number support
- removes broken magic methods
- moves `__iadd__`/`__isub__` impl into `_scal`. The former are no longer called by `ListVectorArray`.